### PR TITLE
Reduce API surface for consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ npm install ember-cli-auto-complete --save-dev
 
 ## How to use this component
 
-First add a custom component that extends AutoComplete. In this component you need to add 1 computed property, 1 function and 1 string variable.
+First add a custom component that extends AutoComplete. In this component you need to add 1 function and 1 string variable.
 
 ```
-1) determineSuggestions:    this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
-2) optionsToMatch: this computed will determine if the value entered is valid (when the user omits to click/enter/tab the selection)
-3) valueProperty:  this string should be the value property for the options passed in (think selectbox value/label)
+1) determineSuggestions: this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
+2) valueProperty: this string should be the value property for the options passed in (think selectbox value/label)
 ```
 
 ```js
@@ -31,21 +30,13 @@ import AutoComplete from "ember-cli-auto-complete/components/auto-complete";
 
 export default AutoComplete.extend({
   valueProperty: "code",
-  suggestions: function() {
-      var inputVal = this.get("inputVal") || "";
-      return this.get("options").filter(function(item) {
-          return item.get("code").toLowerCase().indexOf(inputVal.toLowerCase()) > -1;
+  determineSuggestions: function(options, input) {
+      var list = options.filter(function(item) {
+          return item.get("code").toLowerCase().indexOf(input.toLowerCase()) > -1;
       });
-  }.property("inputVal", "options.@each"),
-  optionsToMatch: function() {
-      var caseInsensitiveOptions = [];
-      this.get("options").forEach(function(item) {
-          var value = item.get("code");
-          caseInsensitiveOptions.push(value);
-          caseInsensitiveOptions.push(value.toLowerCase());
-      });
-      return caseInsensitiveOptions;
-  }.property("options.@each")
+
+      return Ember.A(list);
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ npm install ember-cli-auto-complete --save-dev
 
 ## How to use this component
 
-First add a custom component that extends AutoComplete. In this component you need to add 2 computed properties and 1 string variable.
+First add a custom component that extends AutoComplete. In this component you need to add 1 computed property, 1 function and 1 string variable.
 
 ```
-1) suggestions:    this computed will determine how the list of options is filtered as the user enters text
+1) determineSuggestions:    this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
 2) optionsToMatch: this computed will determine if the value entered is valid (when the user omits to click/enter/tab the selection)
 3) valueProperty:  this string should be the value property for the options passed in (think selectbox value/label)
 ```

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -94,6 +94,13 @@ export default Ember.Component.extend({
     }
   },
 
+  onInput: Ember.observer('selectedValue', function() {
+    var options = this.get("options");
+    var input = this.getWithDefault("selectedValue", "");
+
+    this.set("suggestions", this.determineSuggestions(options, input));
+  }),
+
   highlight: function (direction) {
     var length = this.get("suggestions").length;
     var currentHighlight = this.get("highlightIndex");

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -59,13 +59,9 @@ export default Ember.Component.extend({
         return;
       }
       self.set("visibility", HIDDEN);
-      if (!self.get("selectedFromList")) {
-        var value = this.get("selectedValue").toLowerCase();
-        var optionsToMatch = this.get("optionsToMatch");
-        if (optionsToMatch.indexOf(value) === -1) {
-          self.set("inputVal", "");
-          self.set("selectedValue", "");
-        }
+      if (!self.get("selectedFromList") && !self.hasInputMatchingSuggestion()) {
+        self.set("inputVal", "");
+        self.set("selectedValue", "");
       }
     };
     focusOutEvent = Ember.run.later(this, func, 200);
@@ -80,13 +76,9 @@ export default Ember.Component.extend({
         if (!Ember.isBlank(this.selectableSuggestion)) {
           this.send("selectItem", this.selectableSuggestion);
           this.set("visibility", HIDDEN);
-        } else {
-          var value = this.get("selectedValue").toLowerCase();
-          var optionsToMatch = this.get("optionsToMatch");
-          if (optionsToMatch.indexOf(value) >= 0) {
-            this.set("selectedFromList", true);
-            this.set("visibility", HIDDEN);
-          }
+        } else if (this.hasInputMatchingSuggestion()) {
+          this.set("selectedFromList", true);
+          this.set("visibility", HIDDEN);
         }
       }
     } else {
@@ -114,6 +106,14 @@ export default Ember.Component.extend({
     newSelectedItem.set("highlight", true);
     this.set("selectableSuggestion", newSelectedItem);
     this.set("highlightIndex", nextHighlight);
+  },
+  hasInputMatchingSuggestion: function() {
+    var suggestions = this.get('suggestions');
+    var input = this.getWithDefault('selectedValue', '').toLowerCase();
+
+    if (suggestions.length !== 1) { return false; }
+
+    return input === suggestions[0].get(this.get('valueProperty')).toLowerCase();
   },
   actions: {
     selectItem: function (item) {

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -60,7 +60,7 @@ export default Ember.Component.extend({
       }
       self.set("visibility", HIDDEN);
       if (!self.get("selectedFromList")) {
-        var value = this.get("selectedValue");
+        var value = this.get("selectedValue").toLowerCase();
         var optionsToMatch = this.get("optionsToMatch");
         if (optionsToMatch.indexOf(value) === -1) {
           self.set("inputVal", "");
@@ -81,7 +81,7 @@ export default Ember.Component.extend({
           this.send("selectItem", this.selectableSuggestion);
           this.set("visibility", HIDDEN);
         } else {
-          var value = this.get("selectedValue");
+          var value = this.get("selectedValue").toLowerCase();
           var optionsToMatch = this.get("optionsToMatch");
           if (optionsToMatch.indexOf(value) >= 0) {
             this.set("selectedFromList", true);

--- a/tests/acceptance/end-to-end-test.js
+++ b/tests/acceptance/end-to-end-test.js
@@ -76,6 +76,22 @@ test("typing into the input with a valid value and doing onblur will set value",
   });
 });
 
+test("typing into the input with a valid value in lowercase and doing onblur will set value", function (assert) {
+  visit("/");
+  click("input.typeahead");
+  fillIn("input.typeahead", "Abc");
+  triggerEvent("input.typeahead", "keyup", LETTER_A);
+  triggerEvent("input.typeahead", "keyup", LETTER_B);
+  triggerEvent("input.typeahead", "keyup", LETTER_C);
+  andThen(function () {
+    assert.equal(find(".tt-suggestion").length, 1);
+  });
+  triggerEvent("input.typeahead", "blur");
+  andThen(function () {
+    assert.equal(find("input.typeahead").val(), "Abc");
+  });
+});
+
 test("typing into the input with an invalid value and doing onblur will not set value", function (assert) {
   visit("/");
   click("input.typeahead");

--- a/tests/dummy/app/components/my-auto-complete.js
+++ b/tests/dummy/app/components/my-auto-complete.js
@@ -3,13 +3,13 @@ import AutoComplete from "ember-cli-auto-complete/components/auto-complete";
 
 export default AutoComplete.extend({
   valueProperty: "code",
-  suggestions: Ember.computed("inputVal", "options.[]", function() {
-      var inputVal = this.get("inputVal") || "";
-      var list = this.get("options").filter(function(item) {
-          return item.get("code").toLowerCase().indexOf(inputVal.toLowerCase()) > -1;
+  determineSuggestions: function(options, input) {
+      var list = options.filter(function(item) {
+          return item.get("code").toLowerCase().indexOf(input.toLowerCase()) > -1;
       });
+
       return Ember.A(list);
-  }),
+  },
   optionsToMatch: Ember.computed("options.[]", function() {
       var caseInsensitiveOptions = [];
       this.get("options").forEach(function(item) {

--- a/tests/dummy/app/components/my-auto-complete.js
+++ b/tests/dummy/app/components/my-auto-complete.js
@@ -9,14 +9,5 @@ export default AutoComplete.extend({
       });
 
       return Ember.A(list);
-  },
-  optionsToMatch: Ember.computed("options.[]", function() {
-      var caseInsensitiveOptions = [];
-      this.get("options").forEach(function(item) {
-          var value = item.get("code");
-          caseInsensitiveOptions.push(value);
-          caseInsensitiveOptions.push(value.toLowerCase());
-      });
-      return caseInsensitiveOptions;
-  })
+  }
 });


### PR DESCRIPTION
As mentioned in the issue this pull request reduces the API surface for the components consumers. I don't know how you want to handle this breaking change?

The commit messages are fairly extensive and tell the whole story.

My main motivation was to get rid of `optionsToMatch` since the same can be accomplished by using `suggestions` alone. This removes the burden to implement a kind of weird computed property thats purpose is hard to understand. (At least for me.)

The second thing is removing the `suggestions` computed property and moving the logic into a function. The computed property had the problem of being coupled to the internals of the component.

Next step is adding the `minimumInputLength` attribute to control when the suggestions are shown. This will happen in a new pull request, I'm not yet sure how to go forward with this:
1. We make the `minimumInputLength` default to `0` which effectively breaks nothing. But then is the question how we test this? I can only think of setting up a new component + route in the dummy application.
2. We make the `minimumInputLength` default to something else and have to adapt all tests.

Your thoughts @toranb?
