### PR TITLE
removed inline styles

### DIFF
--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -1,11 +1,10 @@
 import Ember from "ember";
 import KeyCodes from '../utilities/key-codes';
 
-var htmlSafe = Ember.String.htmlSafe;
 var focusOutEvent;
 
-const VISIBLE = "display:block;";
-const HIDDEN = "display:none;";
+const VISIBLE = "visible";
+const HIDDEN = "hidden";
 
 function getNewHighlightIndex(direction, index, length) {
   if (direction === "down" && index < length - 1) {
@@ -36,20 +35,20 @@ export default Ember.Component.extend({
   }),
   keyUp: function (event) {
     if (KeyCodes.keyPressed(event) === "escape") {
-      this.set("visibility", htmlSafe(HIDDEN));
+      this.set("visibility", HIDDEN);
     } else if (!KeyCodes.isEscapedCode(event)) {
       this.set("highlightIndex", -1);
       this.get("options").forEach(function (item) {
         item.set("highlight", false);
       });
-      this.set("visibility", htmlSafe(VISIBLE));
+      this.set("visibility", VISIBLE);
       this.set("inputVal", Ember.$(event.target).val());
     }
     keepHighlightInView(event);
   },
   focusIn: function () {
     if (this.get("visibility") === HIDDEN) {
-      this.set("visibility", htmlSafe(VISIBLE));
+      this.set("visibility", VISIBLE);
     }
   },
   focusOut: function () {
@@ -80,18 +79,18 @@ export default Ember.Component.extend({
       } else if (KeyCodes.keyPressed(event) === "enter" || KeyCodes.keyPressed(event) === "tab") {
         if (!Ember.isBlank(this.selectableSuggestion)) {
           this.send("selectItem", this.selectableSuggestion);
-          this.set("visibility", htmlSafe(HIDDEN));
+          this.set("visibility", HIDDEN);
         } else {
           var value = this.get("selectedValue");
           var optionsToMatch = this.get("optionsToMatch");
           if (optionsToMatch.indexOf(value) >= 0) {
             this.set("selectedFromList", true);
-            this.set("visibility", htmlSafe(HIDDEN));
+            this.set("visibility", HIDDEN);
           }
         }
       }
     } else {
-      this.set("visibility", htmlSafe(VISIBLE));
+      this.set("visibility", VISIBLE);
     }
   },
 

--- a/app/templates/components/auto-complete.hbs
+++ b/app/templates/components/auto-complete.hbs
@@ -1,6 +1,6 @@
 <div class="typeahead-wrap">
 {{input class=inputClazz value=selectedValue placeholder=placeHolderText autocomplete="off" spellcheck="false"}}
-<span class="tt-dropdown-menu" style={{visibility}}>
+<span class="tt-dropdown-menu {{visibility}}">
   <div class="tt-dataset-states">
     <span class="tt-suggestions">
     {{#each suggestions as |result|}}

--- a/vendor/auto-complete.css
+++ b/vendor/auto-complete.css
@@ -26,7 +26,7 @@ html {
   color: #91acbc;
 }
 
-:-ms-input-placeholder {  
+:-ms-input-placeholder {
   color: #91acbc;
 }
 
@@ -54,6 +54,14 @@ input[type="text"] {
 .typeahead-wrap {
   display: block;
   position: relative;
+}
+
+.tt-dropdown-menu.hidden {
+  display: none;
+}
+
+.tt-dropdown-menu.visible {
+  display: block;
 }
 
 .tt-dropdown-menu {


### PR DESCRIPTION
@toranb take a look at this pull request to get rid of inline styles.

--- error ---   [Report Only] Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-0EZqoz-oBhx7gF4nvY2bSqoGyy4zLjNF-SDQXGp_ZrY='), or a nonce ('nonce-...') is required to enable inline execution.
