### PR TITLE
add hideWhenNoSuggestions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ selected `item`, bubbling through your routes and controllers.
   }
 ```
 
+##  Styling Attributes
+
+If you would like to hide the dropdown when there are no suggestions,
+set the `hideWhenNoSuggestions` attribute.
+
+```js
+{{#my-auto-complete
+   ...
+   hideWhenNoSuggestions=true
+   ...             }}
+```
+
+When you set this options, you will generally not want to set the `noMesssagePlaceHolderText` attribute.
+
 ## Running the unit tests
 
     npm install

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -29,6 +29,7 @@ export default Ember.Component.extend({
   layoutName: "components/auto-complete",
   highlightIndex: -1,
   visibility: HIDDEN,
+  hideWhenNoSuggestions: false,
   inputClass: '',
   inputClazz: Ember.computed(function () {
     return "typeahead text-input " + this.get('inputClass');
@@ -41,14 +42,14 @@ export default Ember.Component.extend({
       this.get("options").forEach(function (item) {
         item.set("highlight", false);
       });
-      this.set("visibility", VISIBLE);
+      this.setVisible();
       this.set("inputVal", Ember.$(event.target).val());
     }
     keepHighlightInView(event);
   },
   focusIn: function () {
     if (this.get("visibility") === HIDDEN) {
-      this.set("visibility", VISIBLE);
+      this.setVisible();
     }
   },
   focusOut: function () {
@@ -82,7 +83,7 @@ export default Ember.Component.extend({
         }
       }
     } else {
-      this.set("visibility", VISIBLE);
+      this.setVisible();
     }
   },
 
@@ -114,6 +115,10 @@ export default Ember.Component.extend({
     if (suggestions.length !== 1) { return false; }
 
     return input === suggestions[0].get(this.get('valueProperty')).toLowerCase();
+  },
+  setVisible(){
+    let visible =  !this.get('hideWhenNoSuggestions') || this.get('suggestions').length > 0;
+    this.set('visibility', (visible ? VISIBLE : HIDDEN));
   },
   actions: {
     selectItem: function (item) {

--- a/tests/acceptance/end-to-end-test.js
+++ b/tests/acceptance/end-to-end-test.js
@@ -271,6 +271,21 @@ test("typing into the input will show no matching message when filter does not m
   });
 });
 
+test("when hideWhenNoSuggestions set, drowdown is hidden when filter does not match", function (assert) {
+  visit("/");
+  click("#hide-when-no-suggestions");
+  click("input.typeahead");
+  andThen(function () {
+    assert.equal(find(".tt-suggestion").length, 14);
+  });
+  fillIn("input.typeahead", "X");
+  triggerEvent("input.typeahead", "keyup", LETTER_X);
+  andThen(function () {
+    assert.equal(find(".tt-suggestion").length, 0);
+    assert.equal(find(".tt-dropdown-menu.hidden").length, 1);
+  });
+});
+
 test("typing a value that matches based on filter is set using the original/raw input value", function (assert) {
   visit("/");
   click("input.typeahead");

--- a/tests/dummy/app/controllers/foo.js
+++ b/tests/dummy/app/controllers/foo.js
@@ -1,5 +1,9 @@
 import Ember from "ember";
 
 export default Ember.Controller.extend({
-  selection: ""
+  selection: "",
+  hideWhenNoSuggestions: false,
+  noMessagePlaceholder: Ember.computed('hideWhenNoSuggestions', function(){
+    return this.get('hideWhenNoSuggestions') ? null : "No things are found";
+  }),
 });

--- a/tests/dummy/app/templates/foo.hbs
+++ b/tests/dummy/app/templates/foo.hbs
@@ -1,3 +1,9 @@
+<p>
+<strong>Styling Options:</strong>
+   {{input type="checkbox" id="hide-when-no-suggestions" checked=hideWhenNoSuggestions}}
+  <label>Hide Dropdown When No Suggestions</label>
+</p>
+
 Code: <h2>{{model.code}}</h2>
 
 <br />
@@ -7,7 +13,8 @@ Code: <h2>{{model.code}}</h2>
    selectedValue=model.code
    placeHolderText="Find a thing"
    inputClass="my-fun-input-thing andTwo"
-   noMesssagePlaceHolderText="No things are found"
+   noMesssagePlaceHolderText=noMessagePlaceholder
+   hideWhenNoSuggestions=hideWhenNoSuggestions
    selectItem="itemSelected" as |result|}}
   <p><b>{{result.code}}</b>{{result.text}}</p>
 {{/my-auto-complete}}


### PR DESCRIPTION
I wanted to emulate Evernote tags behavior where the suggestions dropdown disappears if no suggestions.  This PR implements that behavior and allows it to be configured.

If you like the feature, I will add tests and documentation to the PR.
