### PR TITLE
Updating errors in readme and small bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,30 @@ npm install ember-cli-auto-complete --save-dev
 
 ## How to use this component
 
-First add a custom component that extends AutoComplete. In this component you need to add 1 function and 1 string variable.
+Add a custom component that extends AutoComplete, e.g.:
 
 ```
-1) determineSuggestions: this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
-2) valueProperty: this string should be the value property for the options passed in (think selectbox value/label)
+ember generate component my-auto-complete.
 ```
+
+Note: if you use use ember-cli to generate the component, it will create a template file e.g. `my-auto-complete.hbs`. Delete this if you don't intend to use it.
+
+In this component you need to set the `valueProperty` property and implement `suggestions`:
+
+1) `valueProperty` this string should be the value property for the options passed in (think selectbox value/label)
+2) `suggestions` this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
+
+e.g.
 
 ```js
 import AutoComplete from "ember-cli-auto-complete/components/auto-complete";
 
 export default AutoComplete.extend({
   valueProperty: "code",
-  determineSuggestions: function(options, input) {
+  suggestions: function(options, input) {
       var list = options.filter(function(item) {
           return item.get("code").toLowerCase().indexOf(input.toLowerCase()) > -1;
       });
-
       return Ember.A(list);
   }
 });

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install ember-cli-auto-complete --save-dev
 
 ## How to use this component
 
-Add a custom component that extends AutoComplete, e.g.:
+Add a custom component that extends AutoComplete, e.g. with ember-cli:
 
 ```
 ember generate component my-auto-complete.
@@ -28,8 +28,8 @@ Note: if you use use ember-cli to generate the component, it will create a templ
 
 In this component you need to set the `valueProperty` property and implement `suggestions`:
 
-1) `valueProperty` this string should be the value property for the options passed in (think selectbox value/label)
-2) `suggestions` this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
+1. `valueProperty` this string should be the value property for the options passed in (think selectbox value/label)
+2. `suggestions` this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
 
 e.g.
 

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -31,9 +31,13 @@ export default Ember.Component.extend({
   visibility: HIDDEN,
   hideWhenNoSuggestions: false,
   inputClass: '',
+  selectedValue: '',
   inputClazz: Ember.computed(function () {
     return "typeahead text-input " + this.get('inputClass');
   }),
+  optionsToMatch: function() {
+    return this.get("options");
+  },
   keyUp: function (event) {
     if (KeyCodes.keyPressed(event) === "escape") {
       this.set("visibility", HIDDEN);

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -31,7 +31,6 @@ export default Ember.Component.extend({
   visibility: HIDDEN,
   hideWhenNoSuggestions: false,
   inputClass: '',
-  selectedValue: '',
   inputClazz: Ember.computed(function () {
     return "typeahead text-input " + this.get('inputClass');
   }),


### PR DESCRIPTION
I've updated a few errors in the readme.

Also, `optionsToMatch` needs to be implemented. This tripped me up when I used it the first time. I was going to suggest users do that themselves in the readme, but the more I thought about it, it should really be set by default.
