### PR TITLE
Fixing in bug in suggestions list visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: if you use use ember-cli to generate the component, it will create a templ
 In this component you need to set the `valueProperty` property and implement `suggestions`:
 
 1. `valueProperty` this string should be the value property for the options passed in (think selectbox value/label)
-2. `suggestions` this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input)
+2. `determineSuggestions` this function will determine how the list of options is filtered as the user enters text (it gets passed the available options and the users input). This function should return an array.
 
 e.g.
 
@@ -38,7 +38,7 @@ import AutoComplete from "ember-cli-auto-complete/components/auto-complete";
 
 export default AutoComplete.extend({
   valueProperty: "code",
-  suggestions: function(options, input) {
+  determineSuggestions: function(options, input) {
       var list = options.filter(function(item) {
           return item.get("code").toLowerCase().indexOf(input.toLowerCase()) > -1;
       });

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -92,7 +92,9 @@ export default Ember.Component.extend({
   },
 
   onInput: Ember.observer('inputVal', function() {
-    this.set("suggestions", this.get('determineSuggestions'));
+    var options = this.get("options");
+    var input = this.getWithDefault("selectedValue", "");
+    this.set("suggestions", this.determineSuggestions(options, input));
   }),
 
   highlight: function (direction) {

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -91,7 +91,7 @@ export default Ember.Component.extend({
     }
   },
 
-  onInput: Ember.observer('inputVal', function() {
+  onInput: Ember.observer('selectedValue', function() {
     var options = this.get("options");
     var input = this.getWithDefault("selectedValue", "");
     this.set("suggestions", this.determineSuggestions(options, input));

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -30,11 +30,13 @@ export default Ember.Component.extend({
   highlightIndex: -1,
   visibility: HIDDEN,
   hideWhenNoSuggestions: false,
-  suggestions: [],
   inputClass: '',
   inputClazz: Ember.computed(function () {
     return "typeahead text-input " + this.get('inputClass');
   }),
+  optionsToMatch: function() {
+    return this.get("options");
+  },
   keyUp: function (event) {
     if (KeyCodes.keyPressed(event) === "escape") {
       this.set("visibility", HIDDEN);

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -34,6 +34,7 @@ export default Ember.Component.extend({
   inputClazz: Ember.computed(function () {
     return "typeahead text-input " + this.get('inputClass');
   }),
+  suggestions: [],
   optionsToMatch: function() {
     return this.get("options");
   },

--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -30,13 +30,11 @@ export default Ember.Component.extend({
   highlightIndex: -1,
   visibility: HIDDEN,
   hideWhenNoSuggestions: false,
+  suggestions: [],
   inputClass: '',
   inputClazz: Ember.computed(function () {
     return "typeahead text-input " + this.get('inputClass');
   }),
-  optionsToMatch: function() {
-    return this.get("options");
-  },
   keyUp: function (event) {
     if (KeyCodes.keyPressed(event) === "escape") {
       this.set("visibility", HIDDEN);
@@ -45,8 +43,8 @@ export default Ember.Component.extend({
       this.get("options").forEach(function (item) {
         item.set("highlight", false);
       });
-      this.setVisible();
       this.set("inputVal", Ember.$(event.target).val());
+      this.setVisible();
     }
     keepHighlightInView(event);
   },
@@ -90,11 +88,8 @@ export default Ember.Component.extend({
     }
   },
 
-  onInput: Ember.observer('selectedValue', function() {
-    var options = this.get("options");
-    var input = this.getWithDefault("selectedValue", "");
-
-    this.set("suggestions", this.determineSuggestions(options, input));
+  onInput: Ember.observer('inputVal', function() {
+    this.set("suggestions", this.get('determineSuggestions'));
   }),
 
   highlight: function (direction) {
@@ -128,7 +123,6 @@ export default Ember.Component.extend({
       var valueProperty = this.get("valueProperty");
       this.set("selectedFromList", true);
       this.set("selectedValue", item.get(valueProperty));
-
       this.sendAction('selectItem', item);
     }
   }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var path = require('path');
 module.exports = {
     name: 'ember-cli-auto-complete',
     included: function(app) {
-        app.import(path.join('vendor', 'auto-complete.css'));
+    	if (app.app) {
+	        app = app.app;
+	    }
+	    this.app = app;
+	    app.import(path.join('vendor', 'auto-complete.css'));
     }
 };


### PR DESCRIPTION
Hi Toran,

After looking at how `onInput` functions, I realised that the `suggestions` array is populated by the user's implementation of `determineSuggestions` after user input is received. I said before that you don't need `determineSuggestions` and that you should just implement `suggestions`, but I was wrong about that. So I've added it back into the documentation.

However, `onInput` needed updating. Hopefully it's self explanatory, but the user should implement `determineSuggestions` as an Ember computed property, not as a function.

I also had a use case that demonstrated a bug: if you have a really long list of suggestions, you may not want to return any suggestions until the user has typed at least 3 characters (for example), otherwise it works really slowly. Here's an example implementation of `determineSuggestions` that does that:

```
determineSuggestions: function() {
    var inputVal = this.get("inputVal") || "";
    if (inputVal.length >= 3) {
        return this.get("options").filter(function(item) {
            return item.get("label").toLowerCase().indexOf(inputVal.toLowerCase()) > -1;
        });
    }
    return [];
}.property("inputVal", "options.@each")
```

The bug is that the suggestions list stays hidden until the user has typed 4 characters (in this example...the general case is that it stays hidden until the user type x + 1 chars where x is the length of `inputVal`). Triggering `onInput` by a change in `inputVal` and triggering `setVisible` after that change fixes the problem. This means `suggestions` should be initialised as an empty array to avoid errors.
