### PR TITLE
Allow suggestions to be plain objects

### DIFF
--- a/addon/components/auto-complete.js
+++ b/addon/components/auto-complete.js
@@ -1,5 +1,6 @@
 import Ember from "ember";
 import KeyCodes from '../utilities/key-codes';
+const { get, set } = Ember;
 
 var focusOutEvent;
 
@@ -44,7 +45,7 @@ export default Ember.Component.extend({
     } else if (!KeyCodes.isEscapedCode(event)) {
       this.set("highlightIndex", -1);
       this.get("options").forEach(function (item) {
-        item.set("highlight", false);
+        set(item, "highlight", false);
       });
       this.set("inputVal", Ember.$(event.target).val());
       this.setVisible();
@@ -103,11 +104,12 @@ export default Ember.Component.extend({
     var nextHighlight = getNewHighlightIndex(direction, currentHighlight, length);
 
     if (currentHighlight >= 0) {
-      this.get("suggestions").objectAt(currentHighlight).set("highlight", false);
+      var suggestion = this.get("suggestions").objectAt(currentHighlight);
+      set(suggestion, "highlight", false);
     }
 
     var newSelectedItem = this.get("suggestions").objectAt(nextHighlight);
-    newSelectedItem.set("highlight", true);
+    set(newSelectedItem, "highlight", true);
     this.set("selectableSuggestion", newSelectedItem);
     this.set("highlightIndex", nextHighlight);
   },
@@ -117,7 +119,7 @@ export default Ember.Component.extend({
 
     if (suggestions.length !== 1) { return false; }
 
-    return input === suggestions[0].get(this.get('valueProperty')).toLowerCase();
+    return input === get(suggestions[0], this.get('valueProperty')).toLowerCase();
   },
   setVisible(){
     let visible =  !this.get('hideWhenNoSuggestions') || this.get('suggestions').length > 0;
@@ -127,7 +129,7 @@ export default Ember.Component.extend({
     selectItem: function (item) {
       var valueProperty = this.get("valueProperty");
       this.set("selectedFromList", true);
-      this.set("selectedValue", item.get(valueProperty));
+      this.set("selectedValue", get(item, valueProperty));
       this.sendAction('selectItem', item);
     }
   }

--- a/tests/dummy/app/components/my-auto-complete.js
+++ b/tests/dummy/app/components/my-auto-complete.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 import AutoComplete from "ember-cli-auto-complete/components/auto-complete";
+const { get } = Ember;
 
 export default AutoComplete.extend({
   valueProperty: "code",
   determineSuggestions: function(options, input) {
       var list = options.filter(function(item) {
-          return item.get("code").toLowerCase().indexOf(input.toLowerCase()) > -1;
+          return get(item, "code").toLowerCase().indexOf(input.toLowerCase()) > -1;
       });
 
       return Ember.A(list);

--- a/tests/dummy/app/routes/foo.js
+++ b/tests/dummy/app/routes/foo.js
@@ -1,25 +1,25 @@
 import Ember from "ember";
+const { get } = Ember;
 
-var Foo = Ember.Object.extend({});
 var Bar = Ember.Object.extend({code: ""});
 
 export default Ember.Route.extend({
   model: function() {
     var codes = Ember.A([]);
-    codes.pushObject(Foo.create({code: "ABC", text: "SOMETHING 1"}));
-    codes.pushObject(Foo.create({code: "ABD", text: "SOMETHING 2"}));
-    codes.pushObject(Foo.create({code: "ABZ", text: "SOMETHING 3"}));
-    codes.pushObject(Foo.create({code: "BDE", text: "SOMETHING 4"}));
-    codes.pushObject(Foo.create({code: "BFN", text: "SOMETHING 5"}));
-    codes.pushObject(Foo.create({code: "BFZ", text: "SOMETHING 6"}));
-    codes.pushObject(Foo.create({code: "BFC", text: "SOMETHING 7"}));
-    codes.pushObject(Foo.create({code: "BZN", text: "SOMETHING 8"}));
-    codes.pushObject(Foo.create({code: "BZZ", text: "SOMETHING 9"}));
-    codes.pushObject(Foo.create({code: "BZA", text: "SOMETHING 10"}));
-    codes.pushObject(Foo.create({code: "BZB", text: "SOMETHING 11"}));
-    codes.pushObject(Foo.create({code: "BZC", text: "SOMETHING 12"}));
-    codes.pushObject(Foo.create({code: "BZD", text: "SOMETHING 13"}));
-    codes.pushObject(Foo.create({code: "BZE", text: "SOMETHING 14"}));
+    codes.pushObject({code: "ABC", text: "SOMETHING 1"});
+    codes.pushObject({code: "ABD", text: "SOMETHING 2"});
+    codes.pushObject({code: "ABZ", text: "SOMETHING 3"});
+    codes.pushObject({code: "BDE", text: "SOMETHING 4"});
+    codes.pushObject({code: "BFN", text: "SOMETHING 5"});
+    codes.pushObject({code: "BFZ", text: "SOMETHING 6"});
+    codes.pushObject({code: "BFC", text: "SOMETHING 7"});
+    codes.pushObject({code: "BZN", text: "SOMETHING 8"});
+    codes.pushObject({code: "BZZ", text: "SOMETHING 9"});
+    codes.pushObject({code: "BZA", text: "SOMETHING 10"});
+    codes.pushObject({code: "BZB", text: "SOMETHING 11"});
+    codes.pushObject({code: "BZC", text: "SOMETHING 12"});
+    codes.pushObject({code: "BZD", text: "SOMETHING 13"});
+    codes.pushObject({code: "BZE", text: "SOMETHING 14"});
     return Ember.RSVP.hash({
       model: Bar.create(),
       codes: codes
@@ -31,7 +31,7 @@ export default Ember.Route.extend({
   },
   actions: {
     itemSelected: function(item) {
-      this.get('controller').set('selection', item.get('code'));
+      this.get('controller').set('selection', get(item, 'code'));
     }
   }
 });


### PR DESCRIPTION
Hey @toranb, just started using this addon in a project and it looks great! One issue we were having ([which has been mentioned by @jamesarosen](https://github.com/toranb/ember-cli-auto-complete/issues/6#issuecomment-147489423)) is that the data used for suggestions must be an array of Ember.Objects. This PR changes the fixture data to use plain objects which allowed me to flush out all uses of `object.get` and `object.set`. Let me know what you think.
